### PR TITLE
OS check to ensure correct compilation of crosstools-ng

### DIFF
--- a/nerves_toolchain_ctng/build.sh
+++ b/nerves_toolchain_ctng/build.sh
@@ -149,9 +149,15 @@ build_gcc()
     if [[ $CTNG_USE_GIT = "true" ]]; then
         ./bootstrap
     fi
-    ./configure --prefix=$LOCAL_INSTALL_DIR
-    make
-    make install
+    if [[  $HOST_OS = "freebsd" ]]; then
+	./configure --prefix=$LOCAL_INSTALL_DIR --with-sed=/usr/local/bin/gsed --with-make=/usr/local/bin/gmake --with-patch=/usr/local/bin/gpatch
+	gmake
+	gmake install
+    else
+	./configure --prefix=$LOCAL_INSTALL_DIR
+	make
+	make install
+    fi
 
     # Build the toolchain
     mkdir -p $WORK_DIR/build


### PR DESCRIPTION
I found this:

http://crosstool-ng.net/hg/crosstool-ng/file/8398f0469d6a/docs/README.freebsd.txt

And made the appropriate changes to the build.sh file and it's working! It's only been 20 minutes and @fhunleth said it would take ~ 5 hours. I'll watch the build process and report back the status. If this fix works then we can close #2 