### PR TITLE
64-bit ARM updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ $ ../usr/bin/ct-ng savedefconfig
 # in nerves_toolchain_ctng/defaults/<platform>
 ```
 
-## Canadian cross builds for Raspberry Pi
+## 64-bit ARM Builds
+
+It's possible to create cross-compilers for 64-bit ARM machines (aarch64) by
+building the toolchains on a 64-bit ARM machine. Canadian cross builds don't
+seem to work. Build as you would on an x86_64 Linux machine.
+
+## Canadian cross builds for Raspberry Pi (arm)
 
 It's possible to build a toolchain that runs on the Raspberry Pi on x86 Linux.
 This is called a Canadian-cross. To do so, first clone the Raspberry Pi

--- a/nerves_toolchain_aarch64_unknown_linux_gnu/mix.lock
+++ b/nerves_toolchain_aarch64_unknown_linux_gnu/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nerves": {:hex, :nerves, "1.5.4", "d5a2a29a642e92277d5680f40d0fadff17796e75faa82de87ba0bc920ffcf818", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "283ce855f369ff209f3358d25e58f1ac941d58aef3ce7e8cc0be9919d25bf4f5"},
+  "nerves": {:hex, :nerves, "1.6.0", "57c39740659993a51a50184be2843f36f0df42d51e4ef0c1ccd4bd731b3710d8", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "bb388c21249943580f70ccf1845b9793fe35e321d2ea212085097c698b1c78b9"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.7.0", "3e88d5d6cd3e8197121448952b9ccf0c015686245ff26ea85c59b477692ca1ab", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm", "472c21e29ca4cc6cdd20f2a42cca5d013e5d0153076bfc4a12e188ff9f639061"},
 }

--- a/nerves_toolchain_arm_unknown_linux_gnueabihf/mix.lock
+++ b/nerves_toolchain_arm_unknown_linux_gnueabihf/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nerves": {:hex, :nerves, "1.5.4", "d5a2a29a642e92277d5680f40d0fadff17796e75faa82de87ba0bc920ffcf818", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "283ce855f369ff209f3358d25e58f1ac941d58aef3ce7e8cc0be9919d25bf4f5"},
+  "nerves": {:hex, :nerves, "1.6.0", "57c39740659993a51a50184be2843f36f0df42d51e4ef0c1ccd4bd731b3710d8", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "bb388c21249943580f70ccf1845b9793fe35e321d2ea212085097c698b1c78b9"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.7.0", "3e88d5d6cd3e8197121448952b9ccf0c015686245ff26ea85c59b477692ca1ab", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm", "472c21e29ca4cc6cdd20f2a42cca5d013e5d0153076bfc4a12e188ff9f639061"},
 }

--- a/nerves_toolchain_armv5tejl_unknown_linux_musleabi/mix.lock
+++ b/nerves_toolchain_armv5tejl_unknown_linux_musleabi/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nerves": {:hex, :nerves, "1.5.4", "d5a2a29a642e92277d5680f40d0fadff17796e75faa82de87ba0bc920ffcf818", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "283ce855f369ff209f3358d25e58f1ac941d58aef3ce7e8cc0be9919d25bf4f5"},
+  "nerves": {:hex, :nerves, "1.6.0", "57c39740659993a51a50184be2843f36f0df42d51e4ef0c1ccd4bd731b3710d8", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "bb388c21249943580f70ccf1845b9793fe35e321d2ea212085097c698b1c78b9"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.7.0", "3e88d5d6cd3e8197121448952b9ccf0c015686245ff26ea85c59b477692ca1ab", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm", "472c21e29ca4cc6cdd20f2a42cca5d013e5d0153076bfc4a12e188ff9f639061"},
 }

--- a/nerves_toolchain_armv6_rpi_linux_gnueabi/mix.lock
+++ b/nerves_toolchain_armv6_rpi_linux_gnueabi/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nerves": {:hex, :nerves, "1.5.4", "d5a2a29a642e92277d5680f40d0fadff17796e75faa82de87ba0bc920ffcf818", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "283ce855f369ff209f3358d25e58f1ac941d58aef3ce7e8cc0be9919d25bf4f5"},
+  "nerves": {:hex, :nerves, "1.6.0", "57c39740659993a51a50184be2843f36f0df42d51e4ef0c1ccd4bd731b3710d8", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "bb388c21249943580f70ccf1845b9793fe35e321d2ea212085097c698b1c78b9"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.7.0", "3e88d5d6cd3e8197121448952b9ccf0c015686245ff26ea85c59b477692ca1ab", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm", "472c21e29ca4cc6cdd20f2a42cca5d013e5d0153076bfc4a12e188ff9f639061"},
 }

--- a/nerves_toolchain_ctng/defaults/linux_aarch64_defconfig
+++ b/nerves_toolchain_ctng/defaults/linux_aarch64_defconfig
@@ -1,0 +1,11 @@
+CT_CONFIG_VERSION="3"
+CT_GDB_CROSS_STATIC=y
+CT_STATIC_TOOLCHAIN=y
+CT_CC_LANG_CXX=y
+CT_TARBALLS_BUILDROOT_LAYOUT=y
+CT_PREFIX_DIR="../x-tools/${CT_TARGET}"
+
+# Work around an issue with arguments taking up too much memory due to long
+# paths. See "build.sh" for the other part of this workaround.
+CT_WORK_DIR="/tmp/ctng-work"
+

--- a/nerves_toolchain_i586_unknown_linux_gnu/mix.lock
+++ b/nerves_toolchain_i586_unknown_linux_gnu/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nerves": {:hex, :nerves, "1.5.4", "d5a2a29a642e92277d5680f40d0fadff17796e75faa82de87ba0bc920ffcf818", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "283ce855f369ff209f3358d25e58f1ac941d58aef3ce7e8cc0be9919d25bf4f5"},
+  "nerves": {:hex, :nerves, "1.6.0", "57c39740659993a51a50184be2843f36f0df42d51e4ef0c1ccd4bd731b3710d8", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "bb388c21249943580f70ccf1845b9793fe35e321d2ea212085097c698b1c78b9"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.7.0", "3e88d5d6cd3e8197121448952b9ccf0c015686245ff26ea85c59b477692ca1ab", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm", "472c21e29ca4cc6cdd20f2a42cca5d013e5d0153076bfc4a12e188ff9f639061"},
 }

--- a/nerves_toolchain_mipsel_unknown_linux_musl/mix.lock
+++ b/nerves_toolchain_mipsel_unknown_linux_musl/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nerves": {:hex, :nerves, "1.5.4", "d5a2a29a642e92277d5680f40d0fadff17796e75faa82de87ba0bc920ffcf818", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "283ce855f369ff209f3358d25e58f1ac941d58aef3ce7e8cc0be9919d25bf4f5"},
+  "nerves": {:hex, :nerves, "1.6.0", "57c39740659993a51a50184be2843f36f0df42d51e4ef0c1ccd4bd731b3710d8", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "bb388c21249943580f70ccf1845b9793fe35e321d2ea212085097c698b1c78b9"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.7.0", "3e88d5d6cd3e8197121448952b9ccf0c015686245ff26ea85c59b477692ca1ab", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm", "472c21e29ca4cc6cdd20f2a42cca5d013e5d0153076bfc4a12e188ff9f639061"},
 }

--- a/nerves_toolchain_x86_64_unknown_linux_gnu/mix.lock
+++ b/nerves_toolchain_x86_64_unknown_linux_gnu/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nerves": {:hex, :nerves, "1.5.4", "d5a2a29a642e92277d5680f40d0fadff17796e75faa82de87ba0bc920ffcf818", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "283ce855f369ff209f3358d25e58f1ac941d58aef3ce7e8cc0be9919d25bf4f5"},
+  "nerves": {:hex, :nerves, "1.6.0", "57c39740659993a51a50184be2843f36f0df42d51e4ef0c1ccd4bd731b3710d8", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "bb388c21249943580f70ccf1845b9793fe35e321d2ea212085097c698b1c78b9"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.7.0", "3e88d5d6cd3e8197121448952b9ccf0c015686245ff26ea85c59b477692ca1ab", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm", "472c21e29ca4cc6cdd20f2a42cca5d013e5d0153076bfc4a12e188ff9f639061"},
 }

--- a/nerves_toolchain_x86_64_unknown_linux_musl/mix.lock
+++ b/nerves_toolchain_x86_64_unknown_linux_musl/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nerves": {:hex, :nerves, "1.5.4", "d5a2a29a642e92277d5680f40d0fadff17796e75faa82de87ba0bc920ffcf818", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "283ce855f369ff209f3358d25e58f1ac941d58aef3ce7e8cc0be9919d25bf4f5"},
+  "nerves": {:hex, :nerves, "1.6.0", "57c39740659993a51a50184be2843f36f0df42d51e4ef0c1ccd4bd731b3710d8", [:mix], [{:distillery, "~> 2.1", [hex: :distillery, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "bb388c21249943580f70ccf1845b9793fe35e321d2ea212085097c698b1c78b9"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.7.0", "3e88d5d6cd3e8197121448952b9ccf0c015686245ff26ea85c59b477692ca1ab", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm", "472c21e29ca4cc6cdd20f2a42cca5d013e5d0153076bfc4a12e188ff9f639061"},
 }

--- a/support/scripts/clean-all.sh
+++ b/support/scripts/clean-all.sh
@@ -7,7 +7,6 @@ set -e
 for CONFIG in $CONFIGS; do
     echo "Updating deps for $CONFIG..."
     cd $CONFIG
-    mix nerves.clean --all
     rm -rf _build deps .nerves
     cd ../
 done


### PR DESCRIPTION
It looks as if these changes will let us create 64-bit ARM versions of the cross compilers. They're slowly building on an nVidia Jetson Nano, so it will likely be another day or so before I know if it worked.