### PR TITLE
Fix helper script for changing ctng to path dep

### DIFF
--- a/support/scripts/use-ctng-path-dep.sh
+++ b/support/scripts/use-ctng-path-dep.sh
@@ -7,6 +7,6 @@ set -e
 for CONFIG in $CONFIGS; do
     echo "Updating deps for $CONFIG..."
     cd $CONFIG
-    sed -ri 's/nerves_toolchain_ctng, "~> 1...0"/nerves_toolchain_ctng, path: "..\/nerves_toolchain_ctng"/' mix.exs
+    sed -ri 's/nerves_toolchain_ctng, "~> [0-9]+.[0-9]+.[0-9]+"/nerves_toolchain_ctng, path: "..\/nerves_toolchain_ctng"/' mix.exs
     cd ../
 done


### PR DESCRIPTION
Updated the regex to match any version. 