### PR TITLE
Add env key to Nerves package metadata

### DIFF
--- a/nerves_toolchain_aarch64_nerves_linux_gnu/mix.exs
+++ b/nerves_toolchain_aarch64_nerves_linux_gnu/mix.exs
@@ -37,7 +37,11 @@ defmodule NervesToolchainAarch64NervesLinuxGnu.MixProject do
       platform_config: [
         defconfig: "defconfig"
       ],
-      target_tuple: :aarch64_nerves_linux_gnu,
+      env: %{
+        "TARGET_ARCH" => "aarch64",
+        "TARGET_OS" => "linux",
+        "TARGET_ABI" => "gnu",
+      },
       artifact_sites: [
         {:github_releases, "nerves-project/toolchains"}
       ],

--- a/nerves_toolchain_armv5_nerves_linux_musleabi/mix.exs
+++ b/nerves_toolchain_armv5_nerves_linux_musleabi/mix.exs
@@ -37,7 +37,11 @@ defmodule NervesToolchainArmv5NervesLinuxMusleabi.MixProject do
       platform_config: [
         defconfig: "defconfig"
       ],
-      target_tuple: :armv5tejl_nerves_linux_musleabi,
+      env: %{
+        "TARGET_ARCH" => "armv5",
+        "TARGET_OS" => "linux",
+        "TARGET_ABI" => "musleabi",
+      },
       artifact_sites: [
         {:github_releases, "nerves-project/toolchains"}
       ],

--- a/nerves_toolchain_armv6_nerves_linux_gnueabi/mix.exs
+++ b/nerves_toolchain_armv6_nerves_linux_gnueabi/mix.exs
@@ -37,7 +37,11 @@ defmodule NervesToolchainArmv6RpiLinuxGnueabi.MixProject do
       platform_config: [
         defconfig: "defconfig"
       ],
-      target_tuple: :armv6_nerves_linux_gnueabi,
+      env: %{
+        "TARGET_ARCH" => "armv6",
+        "TARGET_OS" => "linux",
+        "TARGET_ABI" => "gnueabi",
+      },
       artifact_sites: [
         {:github_releases, "nerves-project/toolchains"}
       ],

--- a/nerves_toolchain_armv7_nerves_linux_gnueabihf/mix.exs
+++ b/nerves_toolchain_armv7_nerves_linux_gnueabihf/mix.exs
@@ -37,7 +37,11 @@ defmodule NervesToolchainArmV7NervesLinuxGnueabihf.MixProject do
       platform_config: [
         defconfig: "defconfig"
       ],
-      target_tuple: :armv7_nerves_linux_gnueabihf,
+      env: %{
+        "TARGET_ARCH" => "armv7",
+        "TARGET_OS" => "linux",
+        "TARGET_ABI" => "gnueabihf",
+      },
       artifact_sites: [
         {:github_releases, "nerves-project/toolchains"}
       ],

--- a/nerves_toolchain_i586_nerves_linux_gnu/mix.exs
+++ b/nerves_toolchain_i586_nerves_linux_gnu/mix.exs
@@ -37,7 +37,11 @@ defmodule NervesToolchainI586NervesLinuxGnu.MixProject do
       platform_config: [
         defconfig: "defconfig"
       ],
-      target_tuple: :i586_nerves_linux_gnu,
+      env: %{
+        "TARGET_ARCH" => "i586",
+        "TARGET_OS" => "linux",
+        "TARGET_ABI" => "gnu",
+      },
       artifact_sites: [
         {:github_releases, "nerves-project/toolchains"}
       ],

--- a/nerves_toolchain_mipsel_nerves_linux_musl/mix.exs
+++ b/nerves_toolchain_mipsel_nerves_linux_musl/mix.exs
@@ -37,7 +37,11 @@ defmodule NervesToolchainMipselNervesLinuxMusl.MixProject do
       platform_config: [
         defconfig: "defconfig"
       ],
-      target_tuple: :mipsel_nerves_linux_musl,
+      env: %{
+        "TARGET_ARCH" => "mipsel",
+        "TARGET_OS" => "linux",
+        "TARGET_ABI" => "musl",
+      },
       artifact_sites: [
         {:github_releases, "nerves-project/toolchains"}
       ],

--- a/nerves_toolchain_x86_64_nerves_linux_gnu/mix.exs
+++ b/nerves_toolchain_x86_64_nerves_linux_gnu/mix.exs
@@ -37,7 +37,11 @@ defmodule NervesToolchainX8664NervesLinuxGnu.MixProject do
       platform_config: [
         defconfig: "defconfig"
       ],
-      target_tuple: :x86_64_nerves_linux_gnu,
+      env: %{
+        "TARGET_ARCH" => "x86_64",
+        "TARGET_OS" => "linux",
+        "TARGET_ABI" => "gnu",
+      },
       artifact_sites: [
         {:github_releases, "nerves-project/toolchains"}
       ],

--- a/nerves_toolchain_x86_64_nerves_linux_musl/mix.exs
+++ b/nerves_toolchain_x86_64_nerves_linux_musl/mix.exs
@@ -37,7 +37,11 @@ defmodule NervesToolchainX8664NervesLinuxMusl.MixProject do
       platform_config: [
         defconfig: "defconfig"
       ],
-      target_tuple: :x86_64_nerves_linux_musl,
+      env: %{
+        "TARGET_ARCH" => "x86_64",
+        "TARGET_OS" => "linux",
+        "TARGET_ABI" => "musl",
+      },
       artifact_sites: [
         {:github_releases, "nerves-project/toolchains"}
       ],


### PR DESCRIPTION
The env key is expected to pass a map of key value
pairs the build system will export when Nerves bootstraps
the build enviroument. These variables will be set in addition
to the variables defined in the build tool platform bootstrap/0
callbacks.