### PR TITLE
Switch default ARMv7 CPU to a generic one

### DIFF
--- a/nerves_toolchain_armv7_nerves_linux_gnueabihf/defconfig
+++ b/nerves_toolchain_armv7_nerves_linux_gnueabihf/defconfig
@@ -1,6 +1,6 @@
 CT_LOCAL_TARBALLS_DIR="${CT_TOP_DIR}/../dl"
 CT_ARCH_ARM=y
-CT_ARCH_CPU="cortex-a9"
+CT_ARCH_CPU="generic-armv7-a"
 CT_ARCH_SUFFIX="v7"
 CT_ARCH_FPU="vfpv3-d16"
 CT_ARCH_FLOAT_HW=y


### PR DESCRIPTION
I believe that I misunderstood the context of why the Bootlin
configuration for their ARMv7 compiler specified a Cortex-A9. I think
that it uses a generic ARMv7 configuration behind the scenes. This may
explain why we started seeing the Linux kernel handle at least NEON
instruction on the AM3358 (Cortex-A8) rather than it being handled
directly by the processor when we changed to this compiler.
