### PR TITLE
crosstool-ng: bump glibc and binutils

### DIFF
--- a/nerves_toolchain_aarch64_nerves_linux_gnu/mix.lock
+++ b/nerves_toolchain_aarch64_nerves_linux_gnu/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_armv5_nerves_linux_musleabi/mix.lock
+++ b/nerves_toolchain_armv5_nerves_linux_musleabi/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_armv6_nerves_linux_gnueabihf/mix.lock
+++ b/nerves_toolchain_armv6_nerves_linux_gnueabihf/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_armv7_nerves_linux_gnueabihf/mix.lock
+++ b/nerves_toolchain_armv7_nerves_linux_gnueabihf/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_ctng/build.sh
+++ b/nerves_toolchain_ctng/build.sh
@@ -9,7 +9,7 @@ set -e
 # Set CTNG_USE_GIT=true to use git to download the release (only needed for non-released ct-ng builds)
 
 CTNG_USE_GIT=true
-CTNG_TAG=584e57e888fd652ff6228c1dbdff18556149c7cb
+CTNG_TAG=ba680a3e5b8c62a7c1554e71f6d09903dac95a2f
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/nerves_toolchain_ctng/mix.lock
+++ b/nerves_toolchain_ctng/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.12", "7fbe49c14c9f17efdb8213cb86ebf6b186437cfbbf10a9c6ab132bc61eb2ec27", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "43806d6c310959ebdff4e6998a5c330782d1a4bed1267950f4a7ebe9edad3344"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_i586_nerves_linux_gnu/mix.lock
+++ b/nerves_toolchain_i586_nerves_linux_gnu/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_mipsel_nerves_linux_musl/mix.lock
+++ b/nerves_toolchain_mipsel_nerves_linux_musl/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_riscv64_nerves_linux_gnu/mix.lock
+++ b/nerves_toolchain_riscv64_nerves_linux_gnu/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_x86_64_nerves_linux_gnu/mix.lock
+++ b/nerves_toolchain_x86_64_nerves_linux_gnu/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }

--- a/nerves_toolchain_x86_64_nerves_linux_musl/mix.lock
+++ b/nerves_toolchain_x86_64_nerves_linux_musl/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "castore": {:hex, :castore, "0.1.14", "3f6d7c7c1574c402fef29559d3f1a7389ba3524bc6a090a5e9e6abc3af65dcca", [:mix], [], "hexpm", "b34af542eadb727e6c8b37fdf73e18b2e02eb483a4ea0b52fd500bc23f052b7b"},
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},
-  "nerves": {:hex, :nerves, "1.7.13", "3a3c4aedd0d7204748c2e7f4d0acac9bfb8c022d2e489d5018cea5be733d2525", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "906a67bbe35970a0a09cff32b137fa8db8f661a672a7b853115af0f9eba9a321"},
+  "nerves": {:hex, :nerves, "1.7.15", "c9842de9148d1d37111b61d8e1d68373d944ebc4a361ac7e6cb838d95c56882b", [:make, :mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "27539be4013fb63da07bf6e953b96b37da2a7e913e5283c1e6863d17cebe4a35"},
 }


### PR DESCRIPTION
- nerves: bump to 1.7.15
- crosstool-ng: bump glibc and binutils
