### PR TITLE
Update automake/autoconf in Dockerfile

### DIFF
--- a/nerves_toolchain_aarch64_nerves_linux_gnu/mix.exs
+++ b/nerves_toolchain_aarch64_nerves_linux_gnu/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainAarch64NervesLinuxGnu.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.4", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_aarch64_nerves_linux_musl/mix.exs
+++ b/nerves_toolchain_aarch64_nerves_linux_musl/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainAarch64NervesLinuxMusl.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.4", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_armv5_nerves_linux_musleabi/mix.exs
+++ b/nerves_toolchain_armv5_nerves_linux_musleabi/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainArmv5NervesLinuxMusleabi.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_armv6_nerves_linux_gnueabihf/mix.exs
+++ b/nerves_toolchain_armv6_nerves_linux_gnueabihf/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainArmv6RpiLinuxGnueabihf.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_armv7_nerves_linux_gnueabihf/mix.exs
+++ b/nerves_toolchain_armv7_nerves_linux_gnueabihf/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainArmV7NervesLinuxGnueabihf.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_armv7_nerves_linux_musleabihf/mix.exs
+++ b/nerves_toolchain_armv7_nerves_linux_musleabihf/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainArmV7NervesLinuxMusleabihf.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_ctng/build.sh
+++ b/nerves_toolchain_ctng/build.sh
@@ -9,7 +9,7 @@ set -e
 # Set CTNG_USE_GIT=true to use git to download the release (only needed for non-released ct-ng builds)
 
 CTNG_USE_GIT=true
-CTNG_TAG=82346dd7dfe7ed20dc8ec71e193c2d3b1930e22d
+CTNG_TAG=03892881cab1a3ec1e2209ef8bddfb1a0d2a6b0e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/nerves_toolchain_i586_nerves_linux_gnu/mix.exs
+++ b/nerves_toolchain_i586_nerves_linux_gnu/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainI586NervesLinuxGnu.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_mipsel_nerves_linux_musl/mix.exs
+++ b/nerves_toolchain_mipsel_nerves_linux_musl/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainMipselNervesLinuxMusl.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_riscv64_nerves_linux_gnu/mix.exs
+++ b/nerves_toolchain_riscv64_nerves_linux_gnu/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainRISCV64NervesLinuxGNU.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.4", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_riscv64_nerves_linux_musl/mix.exs
+++ b/nerves_toolchain_riscv64_nerves_linux_musl/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainRISCV64NervesLinuxMusl.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.4", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_x86_64_nerves_linux_gnu/mix.exs
+++ b/nerves_toolchain_x86_64_nerves_linux_gnu/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainX8664NervesLinuxGnu.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/nerves_toolchain_x86_64_nerves_linux_musl/mix.exs
+++ b/nerves_toolchain_x86_64_nerves_linux_musl/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesToolchainX8664NervesLinuxMusl.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_toolchain_ctng, "~> 1.9.2", runtime: false}
+      {:nerves_toolchain_ctng, path: "../nerves_toolchain_ctng", runtime: false}
     ]
   end
 

--- a/support/docker/toolchains/Dockerfile
+++ b/support/docker/toolchains/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.13.3-erlang-25.0.2-ubuntu-bionic-20210930
+FROM hexpm/elixir:1.14.2-erlang-25.2-ubuntu-bionic-20210930
 MAINTAINER Nerves Project
 LABEL maintainer="Nerves Project developers <nerves@nerves-project.org>" \
       vendor="NervesProject" \
@@ -8,11 +8,10 @@ description="Container with everything needed to build Nerves toolchains"
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG=C.UTF-8
 ENV TERM=xterm
-# The container has no package lists, so need to update first
-RUN useradd -ms /bin/bash nerves
-RUN set -xe \
-  && apt-get update \
-  && apt-get -y install \
+
+# Install packages
+RUN apt-get update && \
+    apt-get -y install \
 	git \
 	curl \
 	build-essential \
@@ -24,18 +23,43 @@ RUN set -xe \
 	wget \
 	gawk \
 	libtool-bin \
-	automake \
 	libncurses5-dev \
 	help2man \
 	ca-certificates \
 	unzip \
 	lzip \
 	python3 \
-	rsync \
-  && rm -rf /var/lib/apt/lists/* \
-  && mkdir -p /root/.ssh \
-  && ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts \
-  && chmod 700 /root/.ssh \
-  && chmod 600 /root/.ssh/known_hosts
+	rsync && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p /tmp/build
+
+# Install autoconf and automake since Crosstool-NG requires newer versions
+RUN cd /tmp/build && \
+    wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz && \
+    tar xvzf autoconf-2.71.tar.gz && \
+    cd autoconf-2.71 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install
+
+RUN cd /tmp/build && \
+    wget https://ftp.gnu.org/gnu/automake/automake-1.16.tar.gz && \
+    tar xvzf automake-1.16.tar.gz && \
+    cd automake-1.16 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install
+
+RUN rm -fr /tmp/build
+
+# Set up ssh
+RUN mkdir -p /root/.ssh && \
+    ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts && \
+    chmod 700 /root/.ssh && \
+    chmod 600 /root/.ssh/known_hosts
+
+# Add the nerves user
+RUN useradd -ms /bin/bash nerves
 USER nerves


### PR DESCRIPTION
This lets us update Crosstool-NG to get the make 4.4 fix that's needed for MacOS
builds.

- Bump autoconf and automake version in Dockerfile
- Switch to path deps to update ctng
- Bump ctng to include make 4.4 fix
