### PR TITLE
Fix Linux Aarch64 builds

### DIFF
--- a/.github/workflows/build-test-toolchain.yml
+++ b/.github/workflows/build-test-toolchain.yml
@@ -97,7 +97,7 @@ jobs:
 
   build_linux_aarch64:
     name: Build ${{ inputs.toolchain }} on linux-aarch64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     steps:
       - name: Free up disk space
         run: |
@@ -153,7 +153,7 @@ jobs:
   test_linux_aarch64:
     name: Test ${{ inputs.toolchain }} (linux-aarch64) on ubuntu-${{ matrix.ubuntu_version }}-arm
     needs: build_linux_aarch64
-    runs-on: ${{ format('ubuntu-{0}', matrix.ubuntu_version) }}
+    runs-on: ${{ format('ubuntu-{0}-arm', matrix.ubuntu_version) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-test-toolchain.yml
+++ b/.github/workflows/build-test-toolchain.yml
@@ -122,11 +122,24 @@ jobs:
             help2man ca-certificates unzip lzip python3 rsync \
             autoconf automake xz-utils
 
+      # TODO: remove once erlef/setup-beam handles ARM ImageOS values directly.
+      - name: Normalize ImageOS
+        shell: bash
+        run: |
+          echo "ORIGINAL_IMAGE_OS=$ImageOS" >> "$GITHUB_ENV"
+          echo "ImageOS=${ImageOS%-arm64}" >> "$GITHUB_ENV"
+
       - name: Install Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.17.3'
           otp-version: '26.2'
+
+      - name: Restore ImageOS
+        if: always()
+        shell: bash
+        run: |
+          echo "ImageOS=${{ env.ORIGINAL_IMAGE_OS }}" >> "$GITHUB_ENV"
 
       - name: Generate toolchain projects
         run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,28 @@ jobs:
       - name: Prepare artifacts for upload
         run: |
           mkdir -p release-artifacts
-          find artifacts -name "*.tar.xz" -exec cp {} release-artifacts/ \;
+
+          mapfile -t archives < <(find artifacts -type f -name "*.tar.xz" | sort)
+
+          if [ "${#archives[@]}" -eq 0 ]; then
+            echo "No .tar.xz artifacts found"
+            exit 1
+          fi
+
+          duplicate_filenames="$(
+            printf '%s\n' "${archives[@]}" \
+              | xargs -n1 basename \
+              | sort \
+              | uniq -d
+          )"
+
+          if [ -n "${duplicate_filenames}" ]; then
+            echo "Duplicate release artifact filenames detected:"
+            printf '%s\n' "${duplicate_filenames}"
+            exit 1
+          fi
+
+          cp "${archives[@]}" release-artifacts/
           ls -lh release-artifacts/
 
       - name: Extract release notes


### PR DESCRIPTION
The workaround can be removed when https://github.com/erlef/setup-beam/pull/462 is merged or there's another fix. This pretty much copies the workaround done by Livebook.