### PR TITLE
impl's created an inadvertent dependency

### DIFF
--- a/template/lib/package_name.ex.eex
+++ b/template/lib/package_name.ex.eex
@@ -1,29 +1,28 @@
 defmodule <%= @module_name %> do
   @moduledoc false
-  use Nerves.Package.Platform
+  # This module's only purpose is get rid of error messages when used with Nerves 1.x
 
-  @impl Nerves.Package.Platform
+  # The functions needed to be implemented when using Nerves.Package.Platform. Implement
+  # anyway, but don't require Nerves.Package.Platform to be around.
+  # use Nerves.Package.Platform
+
   def bootstrap(_pkg) do
     :ok
   end
 
-  @impl Nerves.Package.Platform
   def build_path_link(_pkg) do
     # Unused since never built via Nerves tooling
     "Run build.sh directly"
   end
 
-  @impl Nerves.Artifact.BuildRunner
   def build(_pkg, _toolchain, _opts) do
     {:error, "Run build.sh directly"}
   end
 
-  @impl Nerves.Artifact.BuildRunner
   def archive(_pkg, _toolchain, _opts) do
     {:error, "Run build.sh directly"}
   end
 
-  @impl Nerves.Artifact.BuildRunner
   def clean(_pkg) do
     {:error, "Run build.sh directly"}
   end

--- a/template/mix.exs.eex
+++ b/template/mix.exs.eex
@@ -16,19 +16,11 @@ defmodule <%= @module_name %>.MixProject do
       description: @description,
       package: package(),
       source_url: @source_url,
-      compilers: compilers(Mix.env()),
       nerves_package: nerves_package(),
       deps: deps(),
       docs: docs()
     ]
   end
-
-  # Removing Nerves.Toolchain.CTNG had the side effect of introducing a
-  # circular dependency between Nerves bootstram and compiling the platform.
-  # Since we no longer support compiling the toolchain via the Nerves tooling,
-  # use the environment to see whether this is the root project or not.
-  defp compilers(:prod), do: [:nerves_package | Mix.compilers()]
-  defp compilers(_), do: Mix.compilers()
 
   def application do
     []

--- a/template/mix.exs.eex
+++ b/template/mix.exs.eex
@@ -45,7 +45,7 @@ defmodule <%= @module_name %>.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},
-      {:nerves, "~> 1.13", runtime: false}
+      {:nerves, "~> 1.13 or ~> 2.0", runtime: false}
     ]
   end
 


### PR DESCRIPTION
The @impl's by the placeholder functions inadvertently created warnings
even though the code to call the callbacks was removed in Nerves 2. This
just gets rid of all external module references to be safe.
